### PR TITLE
Add custom authentication backend.

### DIFF
--- a/api/account/authentication.py
+++ b/api/account/authentication.py
@@ -1,0 +1,75 @@
+from django.contrib.auth import get_user_model
+
+from account import models
+
+
+UserModel = get_user_model()
+
+
+class EmailBackend:
+    """
+    Authentication backend that allows users to login with any verified
+    email address that they own.
+    """
+
+    @staticmethod
+    def authenticate(_, email=None, username=None, password=None):
+        """
+        Authenticate a user.
+
+        Args:
+            _:
+                The request made to authenticate the user. This
+                parameter is required by Django, but unused here.
+            email:
+                The user's email address.
+            username:
+                An alias for the ``email`` parameter. This is used to
+                maintain compatibility with Django's default
+                authentication forms.
+            password:
+                The user's password.
+
+        Returns:
+            The user corresponding to the provided credentials. If no
+            users match, ``None`` is returned.
+
+        Raises:
+            PermissionDenied:
+                If the account of the user corresponding to the provided
+                credentials is not active.
+        """
+        email = email or username
+
+        try:
+            email_instance = models.Email.objects.get(
+                address=email,
+                is_verified=True,
+            )
+        except models.Email.DoesNotExist:
+            return None
+
+        user = email_instance.user
+
+        if not all((user.check_password(password), user.is_active)):
+            return None
+
+        return user
+
+    @staticmethod
+    def get_user(user_id):
+        """
+        Get a user by their ID.
+
+        Args:
+            user_id:
+                The ID of the user to fetch.
+
+        Returns:
+            The user with the provided ID. ``None`` is returned if no
+            user with the provided ID exists.
+        """
+        try:
+            return UserModel.objects.get(id=user_id)
+        except UserModel.DoesNotExist:
+            return None

--- a/api/account/test/authentication/test_email_backend.py
+++ b/api/account/test/authentication/test_email_backend.py
@@ -1,0 +1,142 @@
+import pytest
+
+from account import authentication
+
+PASSWORD = 'password'
+
+
+@pytest.fixture
+def auth_backend() -> authentication.EmailBackend:
+    """
+    Fixture to get an instance of the authentication backend.
+    """
+    return authentication.EmailBackend()
+
+
+def test_authenticate_inactive_user(
+        auth_backend,
+        email_factory,
+        user_factory):
+    """
+    If the provided credentials belong to an inactive user, the ``None``
+    should be returned.
+    """
+    user = user_factory(is_active=False, password=PASSWORD)
+    email = email_factory(is_verified=True, user=user)
+
+    result = auth_backend.authenticate(
+        None,
+        email=email.address,
+        password=PASSWORD,
+    )
+
+    assert result is None
+
+
+def test_authenticate_missing_email(auth_backend, db):
+    """
+    If the provided email address does not exist in the system, ``None``
+    should be returned.
+    """
+    result = auth_backend.authenticate(
+        None,
+        email='non-existent@example.com',
+        password=PASSWORD,
+    )
+
+    assert result is None
+
+
+def test_authenticate_unverified_email(
+        auth_backend,
+        email_factory,
+        user_factory):
+    """
+    If the provided email address exists in the system but has not been
+    verified, authentication should return ``None``.
+    """
+    user = user_factory(password=PASSWORD)
+    email = email_factory(is_verified=False, user=user)
+
+    result = auth_backend.authenticate(
+        None,
+        email=email.address,
+        password=PASSWORD,
+    )
+
+    assert result is None
+
+
+def test_authenticate_valid_credentials(
+        auth_backend,
+        email_factory,
+        user_factory):
+    """
+    If provided valid credentials, the backend should return the
+    corresponding user.
+    """
+    user = user_factory(password=PASSWORD)
+    email = email_factory(is_verified=True, user=user)
+
+    result = auth_backend.authenticate(
+        None,
+        email=email.address,
+        password=PASSWORD,
+    )
+
+    assert result == user
+
+
+def test_authenticate_valid_credentials_alias(
+        auth_backend,
+        email_factory,
+        user_factory):
+    """
+    The ``username`` parameter should be an alias for the ``email``
+    parameter.
+    """
+    user = user_factory(password=PASSWORD)
+    email = email_factory(is_verified=True, user=user)
+
+    result = auth_backend.authenticate(
+        None,
+        password=PASSWORD,
+        username=email.address,
+    )
+
+    assert result == user
+
+
+def test_authenticate_wrong_password(
+        auth_backend,
+        email_factory,
+        user_factory):
+    """
+    If the wrong password is provided, ``None`` should be returned.
+    """
+    user = user_factory(password=PASSWORD)
+    email = email_factory(is_verified=True, user=user)
+
+    result = auth_backend.authenticate(
+        None,
+        email=email.address,
+        password=PASSWORD * 2,
+    )
+
+    assert result is None
+
+
+def test_get_user(auth_backend, user_factory):
+    """
+    The user with the given ID should be returned if they exist.
+    """
+    user = user_factory()
+
+    assert auth_backend.get_user(user.id) == user
+
+
+def test_get_user_invalid_id(auth_backend, db):
+    """
+    If there is no user with the given ID, ``None`` should be returned.
+    """
+    assert auth_backend.get_user(None) is None

--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -109,8 +109,12 @@ AUTH_PASSWORD_VALIDATORS = [
 
 AUTH_USER_MODEL = 'account.User'
 
-# Silence checks related to non-unique username
-SILENCED_SYSTEM_CHECKS = ['auth.E003']
+# Use email authentication
+AUTHENTICATION_BACKENDS = ['account.authentication.EmailBackend']
+
+# Silence checks related to non-unique username since our authentication
+# backend doesn't use usernames.
+SILENCED_SYSTEM_CHECKS = ['auth.W004']
 
 
 # Internationalization

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -10,9 +10,30 @@ class UserFactory(factory.django.DjangoModelFactory):
     Factory for generating user instances.
     """
     name = factory.Sequence(lambda n: f'User {n}')
+    password = 'password'
 
     class Meta:
         model = 'account.User'
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        """
+        Create a new user.
+
+        Args:
+            model_class:
+                The class to instantiate.
+            *args:
+                Positional arguments to pass to the model.
+            **kwargs:
+                Keyword arguments to pass to the model.
+
+        Returns:
+            The newly created user instance.
+        """
+        manager = cls._get_manager(model_class)
+
+        return manager.create_user(*args, **kwargs)
 
 
 @pytest.fixture


### PR DESCRIPTION
The custom backend uses email addresses to authenticate users rather
than usernames.